### PR TITLE
fix: whmcs subdirectory url

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -75,7 +75,7 @@ class Client
     public function url(string $url): void
     {
         $uri = $this->getHttpClientBuilder()->getUriFactory()->createUri($url);
-        $uri = $uri->withPath(self::API_PATH);
+        $uri = $uri->withPath(rtrim($uri->getPath(), '/') . self::API_PATH);
 
         $this->getHttpClientBuilder()->removePlugin(BaseUriPlugin::class);
         $this->getHttpClientBuilder()->addPlugin(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace DarthSoup\Tests\WhmcsApi;
 
 use DarthSoup\WhmcsApi\Client;
+use DarthSoup\WhmcsApi\HttpClient\Builder;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\AppendStream;
+use GuzzleHttp\Psr7\Response;
 use Http\Client\Common\HttpMethodsClient;
 use PHPUnit\Framework\TestCase;
 
@@ -18,5 +24,36 @@ class ClientTest extends TestCase
 
         $this->assertInstanceOf(Client::class, $client);
         $this->assertInstanceOf(HttpMethodsClient::class, $client->getHttpClient());
+    }
+
+    /** @dataProvider urlProvider */
+    public function testWhmcsUrl(string $url, string $expected): void
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack = HandlerStack::create(new MockHandler([new Response]));
+        $handlerStack->push($history);
+
+        $httpClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
+        $builder = new Builder($httpClient);
+
+        $client = new Client($builder);
+        $client->url($url);
+
+        $client->getHttpClient()->post('', [], new AppendStream);
+
+        $this->assertCount(1, $container);
+
+        /** @var \GuzzleHttp\Psr7\Request $request */
+        $request = $container[0]['request'];
+        $this->assertSame($expected, (string) $request->getUri());
+    }
+
+    public function urlProvider(): iterable
+    {
+        yield ['http://example.com/whmcs', 'http://example.com/whmcs/includes/api.php'];
+        yield ['http://example.com/whmcs/', 'http://example.com/whmcs/includes/api.php'];
+        yield ['http://whmcs.example.com', 'http://whmcs.example.com/includes/api.php'];
+        yield ['http://whmcs.example.com/', 'http://whmcs.example.com/includes/api.php'];
     }
 }


### PR DESCRIPTION
Given `http://example.com/whmcs` the library would create `http://example.com/includes/api.php` which is incorrect.