### PR TITLE
Fix customfields definition

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -96,7 +96,7 @@ abstract class AbstractApi
             ->setAllowedTypes('password2', 'string');
 
         $resolver->setDefined('customfields')
-            ->setAllowedTypes('customfields', 'string[]');
+            ->setAllowedTypes('customfields', 'string');
 
         $resolver->setDefined('ip')
             ->setAllowedTypes('ip', 'string')


### PR DESCRIPTION
As per https://developers.whmcs.com/api-reference/addclient/ customfields is a base64 encoded string of a serialised array and should not be an array itself